### PR TITLE
Fixed adding a class path while jvm is running on windows

### DIFF
--- a/Mud/Jvm.cs
+++ b/Mud/Jvm.cs
@@ -330,9 +330,11 @@ public static class Jvm
         if (string.IsNullOrWhiteSpace(path)) return;
         
         path = path.Trim();
-        if (!path.StartsWith("file://"))
+        var filePrefix = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "file:/" : "file://";
+        
+        if (!path.StartsWith(filePrefix))
         {
-            path = $"file://{Path.GetFullPath(path)}";
+            path = $"{filePrefix}{Path.GetFullPath(path)}";
         }
         
         MudInterface.add_class_path(Instance.Env, path);

--- a/Mud/Mud.csproj
+++ b/Mud/Mud.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Mud</PackageId>
-        <Version>0.0.1</Version>
+        <Version>0.0.2</Version>
         <Authors>Nicholas Homme</Authors>
         <Product>Mud</Product>
         <Title>Mud</Title>


### PR DESCRIPTION
When adding a jar file to the JVM via Jvm.AddClassPath the jar would not be loaded when on windows. This was due to the file prefix ending with 2 forward slashes instead of one.